### PR TITLE
adds the missing 'event' parameter to the segmentation average query

### DIFF
--- a/mixpanel_query/client.py
+++ b/mixpanel_query/client.py
@@ -712,6 +712,7 @@ class MixpanelQueryClient(object):
         return self.connection.request(
             'segmentation/average',
             {
+                'event': event_name,
                 'from_date': start_date,
                 'to_date': end_date,
                 'unit': unit,


### PR DESCRIPTION
why
---
'event' was missing from the segmentation average request in the client

what
---
adds the parameter to the request... the method was already accepting it as an argument. And it is required https://mixpanel.com/docs/api-documentation/data-export-api#segmentation-average