### PR TITLE
fixes a unicode/string bug in the raw data export client method

### DIFF
--- a/mixpanel_query/client.py
+++ b/mixpanel_query/client.py
@@ -871,7 +871,9 @@ class MixpanelQueryClient(object):
         if start_date_obj > end_date_obj:
             raise exceptions.InvalidDateException('The `start_date` specified after the `end_date`; you will not receive any events.')
 
-        if isinstance(event, str):
+        # the provided event should be an array even when a singleton
+        # if a singleton string/unicode is provided, put it into an array
+        if event is not None and not isinstance(event, list):
             event = [event]
 
         response = self.connection.raw_request(

--- a/mixpanel_query/client.py
+++ b/mixpanel_query/client.py
@@ -873,7 +873,7 @@ class MixpanelQueryClient(object):
 
         # the provided event should be an array even when a singleton
         # if a singleton string/unicode is provided, put it into an array
-        if event is not None and not isinstance(event, list):
+        if isinstance(event, six.string_types):
             event = [event]
 
         response = self.connection.raw_request(


### PR DESCRIPTION
why
---
when using the ```get_export``` method, you are supposed to pass an array of event names for mixpanel to pull. Our method was generous and tried to detect a singleton event name and auto-wrap it in an array. Unfortunately, it only looked for a string, so if a unicode event name was passed in, a bad request was generated to mixpanel, since mixpanel requires the passed event argument be a url encoded json array.

what
---
broadens a check from checking ```if a string is provided``` to check instead ```is a non-None, non-array provided```