### PR TITLE
Improve authentication method support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ from your_project.conf import MIXPANEL_API_KEY, MIXPANEL_API_SECRET
 secret_auth_client = MixpanelQueryClient(MIXPANEL_API_KEY, MIXPANEL_API_SECRET, auth_class=SecretAuth)
 
 # Instantiate a signature-based auth client explicitly
-sig_auth_client = MixpanelQueryClient(MIXPANEL_API_KEY, MIXPANEL_API_SECRET, auth_class=SigAuth)
+sig_auth_client = MixpanelQueryClient(MIXPANEL_API_KEY, MIXPANEL_API_SECRET, auth_class=SignatureAuth)
 ```
 
 View the [api reference](#api-reference) for details on accessing different endpoints.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ print data
 }
 ```
 
+By default the `MixpanelQueryClient` will use signature-based authentication when issuing requests to Mixpanel. If you would like to use the secret-based authentication method, you can do so like this:
+
+```python
+from mixpanel_query.client import MixpanelQueryClient
+from mixpanel_query.auth import SecretAuth, SignatureAuth
+from your_project.conf import MIXPANEL_API_KEY, MIXPANEL_API_SECRET
+
+# Instantiate a secret-based auth client
+secret_auth_client = MixpanelQueryClient(MIXPANEL_API_KEY, MIXPANEL_API_SECRET, auth_class=SecretAuth)
+
+# Instantiate a signature-based auth client explicitly
+sig_auth_client = MixpanelQueryClient(MIXPANEL_API_KEY, MIXPANEL_API_SECRET, auth_class=SigAuth)
+```
+
 View the [api reference](#api-reference) for details on accessing different endpoints.
 
 # API Reference

--- a/mixpanel_query/auth.py
+++ b/mixpanel_query/auth.py
@@ -1,0 +1,99 @@
+"""
+The classes in this module contain the logic to authenticate an http request to
+the Mixpanel API
+"""
+import hashlib
+import json
+import time
+import base64
+import six
+from six.moves.urllib.parse import urlencode
+from six.moves.urllib import request as url_request
+
+from mixpanel_query.utils import _unicode_urlencode, _totext, _tobytes
+
+
+class SignatureAuth(object):
+    """
+    Signature-based authentication uses your api secret to create and md5 hash
+    of your request's parameters for verification by mixpanel
+
+    This method is deprecated, but mixpanel currently has no plans to remove
+    support for this method of authentication.
+
+    Please see https://mixpanel.com/help/reference/data-export-api#authentication
+    for more details.
+    """
+    DEFAULT_EXPIRATION = 600  # expire requests after 10 minutes
+
+    def __init__(self, client):
+        self.client = client
+
+    def _hash_args(self, args, secret=None):
+        """
+        Hashes arguments by joining key=value pairs, appending the api_secret, and
+        then taking the MD5 hex digest.
+        """
+        for a in args:
+            if isinstance(args[a], list):
+                args[a] = json.dumps(args[a])
+
+        args_joined = six.b('')
+        for a in sorted(args.keys()):
+            args_joined += _tobytes(a)
+            args_joined += six.b('=')
+            args_joined += _tobytes(args[a])
+
+        hash = hashlib.md5(args_joined)
+
+        if secret:
+            hash.update(_tobytes(secret))
+        elif self.client.api_secret:
+            hash.update(_tobytes(self.client.api_secret))
+        return hash.hexdigest()
+
+    def authenticate(self, url, params):
+        """
+        returns a request object ready to be issued to the Mixpanel API
+        """
+        params['api_key'] = self.client.api_key
+        params['expire'] = int(time.time()) + self.DEFAULT_EXPIRATION
+
+        # Creating signature
+        if 'sig' in params:
+            del params['sig']
+        params['sig'] = self._hash_args(params, self.client.api_secret)
+
+        request_url = '{base_url}?{encoded_params}'.format(
+            base_url=url,
+            encoded_params=_unicode_urlencode(params)
+        )
+        return url_request.Request(request_url)
+
+
+class SecretAuth(object):
+    """
+    Secret-based authentication sends your api secret over https for verification
+    by mixpanel.
+
+    This method of authentication is the recommended authentication method.
+
+    Please see https://mixpanel.com/help/reference/data-export-api#authentication
+    for more details.
+    """
+
+    def __init__(self, client):
+        self.client = client
+
+    def authenticate(self, url, params):
+        """
+        returns a request object ready to be issued to the Mixpanel API
+        """
+        request_url = '{base_url}?{encoded_params}'.format(
+            base_url=url,
+            encoded_params=_unicode_urlencode(params)
+        )
+        request_headers = {
+            'Authorization': 'Basic ' + _totext(base64.standard_b64encode(_tobytes("{}:".format(self.client.api_secret))))
+        }
+        return url_request.Request(request_url, headers=request_headers)

--- a/mixpanel_query/auth.py
+++ b/mixpanel_query/auth.py
@@ -2,14 +2,15 @@
 The classes in this module contain the logic to authenticate an http request to
 the Mixpanel API
 """
+import base64
 import hashlib
 import json
 import time
-import base64
-import six
-from six.moves.urllib import request as url_request
 
-from mixpanel_query.utils import _unicode_urlencode, _totext, _tobytes
+import six
+from mixpanel_query.utils import _tobytes, _totext, _unicode_urlencode
+
+from six.moves.urllib import request as url_request
 
 
 class SignatureAuth(object):
@@ -33,15 +34,13 @@ class SignatureAuth(object):
         Hashes arguments by joining key=value pairs, appending the api_secret, and
         then taking the MD5 hex digest.
         """
-        for a in args:
-            if isinstance(args[a], list):
-                args[a] = json.dumps(args[a])
+        for arg in args:
+            if isinstance(args[arg], list):
+                args[arg] = json.dumps(args[arg])
 
-        args_joined = six.b('')
-        for a in sorted(args.keys()):
-            args_joined += _tobytes(a)
-            args_joined += six.b('=')
-            args_joined += _tobytes(args[a])
+        arg_strings = ["{}={}".format(arg, args[arg]) for arg in sorted(args.keys())]
+        args_joined_string = ''.join(arg_strings)
+        args_joined = _tobytes(args_joined_string)
 
         hash = hashlib.md5(args_joined)
 

--- a/mixpanel_query/auth.py
+++ b/mixpanel_query/auth.py
@@ -7,7 +7,6 @@ import json
 import time
 import base64
 import six
-from six.moves.urllib.parse import urlencode
 from six.moves.urllib import request as url_request
 
 from mixpanel_query.utils import _unicode_urlencode, _totext, _tobytes

--- a/mixpanel_query/client.py
+++ b/mixpanel_query/client.py
@@ -35,7 +35,7 @@ class MixpanelQueryClient(object):
     DATA_TYPE_UNIQUE = 'unique'
     VALID_DATA_TYPES = (DATA_TYPE_GENERAL, DATA_TYPE_AVERAGE, DATA_TYPE_UNIQUE)
 
-    def __init__(self, api_key, api_secret, auth_class=SignatureAuth, timeout=None):
+    def __init__(self, api_key, api_secret, timeout=None, auth_class=SignatureAuth):
         self.api_key = _totext(api_key)
         self.api_secret = _totext(api_secret)
         self.timeout = timeout

--- a/mixpanel_query/client.py
+++ b/mixpanel_query/client.py
@@ -5,6 +5,8 @@ import six
 from mixpanel_query import exceptions
 from mixpanel_query.connection import Connection
 from mixpanel_query.utils import _totext
+from mixpanel_query.auth import SignatureAuth
+
 
 class MixpanelQueryClient(object):
     """
@@ -33,11 +35,12 @@ class MixpanelQueryClient(object):
     DATA_TYPE_UNIQUE = 'unique'
     VALID_DATA_TYPES = (DATA_TYPE_GENERAL, DATA_TYPE_AVERAGE, DATA_TYPE_UNIQUE)
 
-    def __init__(self, api_key, api_secret, timeout=None):
+    def __init__(self, api_key, api_secret, auth_class=SignatureAuth, timeout=None):
         self.api_key = _totext(api_key)
         self.api_secret = _totext(api_secret)
         self.timeout = timeout
         self.connection = Connection(self)
+        self.auth = auth_class(self)
 
     # Annotation methods ##############
     def annotations_list(self, start_date, end_date, response_format=FORMAT_JSON):

--- a/mixpanel_query/connection.py
+++ b/mixpanel_query/connection.py
@@ -3,7 +3,9 @@ The class(es) in this module contain logic to make http
 requests to the Mixpanel API.
 """
 import json
+
 import six
+
 from six.moves.urllib import request as url_request
 
 __all__ = ('Connection',)

--- a/mixpanel_query/connection.py
+++ b/mixpanel_query/connection.py
@@ -2,14 +2,9 @@
 The class(es) in this module contain logic to make http
 requests to the Mixpanel API.
 """
-import hashlib
 import json
-import time
 import six
-from six.moves.urllib.parse import urlencode 
 from six.moves.urllib import request as url_request
-
-from mixpanel_query.utils import _tobytes
 
 __all__ = ('Connection',)
 
@@ -18,7 +13,7 @@ class Connection(object):
     The `Connection` object's sole responsibility is to format, send to
     and parse http responses from the Mixpanel API.
     """
-    ENDPOINT = 'http://mixpanel.com/api'
+    ENDPOINT = 'https://mixpanel.com/api'
     DATA_ENDPOINT = 'https://data.mixpanel.com/api'
     VERSION = '2.0'
     DEFAULT_TIMEOUT = 120
@@ -40,62 +35,17 @@ class Connection(object):
         Make a request to the Mixpanel API and return a raw urllib2/url.request file-like
         response object.
         """
-        params['api_key'] = self.client.api_key
-        params['expire'] = int(time.time()) + 600   # Grant this request 10 minutes.
         params['format'] = response_format
         # Getting rid of the None params
         params = self.check_params(params)
-
-        # Creating signature
-        if 'sig' in params:
-            del params['sig']
-        params['sig'] = self.hash_args(params, self.client.api_secret)
-
-        request_url = '{base_url}/{version}/{method_name}/?{encoded_params}'.format(
+        url_without_params = '{base_url}/{version}/{method_name}/'.format(
             base_url=base_url,
             version=self.VERSION,
             method_name=method_name,
-            encoded_params=self.unicode_urlencode(params)
         )
-        return url_request.urlopen(request_url, timeout=self.DEFAULT_TIMEOUT if self.client.timeout is None else self.client.timeout)
-
-    def unicode_urlencode(self, params):
-        """
-        Convert lists to JSON encoded strings, and correctly handle any
-        unicode URL parameters.
-        """
-        if isinstance(params, dict):
-            params = list(six.iteritems(params))
-        for i, param in enumerate(params):
-            if isinstance(param[1], list):
-                params[i] = (param[0], json.dumps(param[1]),)
-
-        return urlencode(
-            [(_tobytes(k), _tobytes(v)) for k, v in params]
-        )
-
-    def hash_args(self, args, secret=None):
-        """
-        Hashes arguments by joining key=value pairs, appending the api_secret, and
-        then taking the MD5 hex digest.
-        """
-        for a in args:
-            if isinstance(args[a], list):
-                args[a] = json.dumps(args[a])
-
-        args_joined = six.b('')
-        for a in sorted(args.keys()):
-            args_joined += _tobytes(a)
-            args_joined += six.b('=')
-            args_joined += _tobytes(args[a])
-
-        hash = hashlib.md5(args_joined)
-
-        if secret:
-            hash.update(_tobytes(secret))
-        elif self.client.api_secret:
-            hash.update(_tobytes(self.client.api_secret))
-        return hash.hexdigest()
+        request_obj = self.client.auth.authenticate(url_without_params, params)
+        effective_timeout = self.DEFAULT_TIMEOUT if self.client.timeout is None else self.client.timeout
+        return url_request.urlopen(request_obj, timeout=effective_timeout)
 
     def check_params(self, params):
         copyParams = params.copy()

--- a/mixpanel_query/utils.py
+++ b/mixpanel_query/utils.py
@@ -1,4 +1,5 @@
 import six
+from six.moves.urllib.parse import urlencode
 
 def _totext(val):
     """
@@ -27,3 +28,18 @@ def _tobytes(val):
         return val.encode('utf-8')
     else:
         return six.text_type(val).encode('utf-8')
+
+def _unicode_urlencode(params):
+    """
+    Convert lists to JSON encoded strings, and correctly handle any
+    unicode URL parameters.
+    """
+    if isinstance(params, dict):
+        params = list(six.iteritems(params))
+    for i, param in enumerate(params):
+        if isinstance(param[1], list):
+            params[i] = (param[0], json.dumps(param[1]),)
+
+    return urlencode(
+        [(_tobytes(k), _tobytes(v)) for k, v in params]
+    )

--- a/mixpanel_query/utils.py
+++ b/mixpanel_query/utils.py
@@ -1,3 +1,4 @@
+import json
 import six
 from six.moves.urllib.parse import urlencode
 

--- a/mixpanel_query/utils.py
+++ b/mixpanel_query/utils.py
@@ -1,6 +1,9 @@
 import json
+
 import six
+
 from six.moves.urllib.parse import urlencode
+
 
 def _totext(val):
     """


### PR DESCRIPTION
why
---
Mixpanel documentation clearly states signature-based authentication is considered deprecated. However, on several occasions we have been informed there are no plans to discontinue support of signature-based authentication. There has been some interest in supporting the new "secret in header" means of authentication. Two PRs have been submitted to that effect:

https://github.com/cooncesean/mixpanel-query-py/pull/27
https://github.com/cooncesean/mixpanel-query-py/pull/29

In the interest of keeping this repo up to date, we should strive to conform to the latest documentation from Mixpanel.

what
---
this PR:

* creates a new `mixpanel_query.auth` module with two classes, `SignatureAuth` and `SecretAuth`
* adjusts `mixpanel_query.client.MixpanelQueryClient` to accept an auth_class upon initialization. This auth class is used to create an instance upon initialization for future use in authorizing requests
* adjusts `mixpanel_query.connection.Connection` to use the client's auth instance to authenticate requests
* moves the `unicode_urlencode` method from the connection class to `mixpanel_query.utils` so both authentication classes could use it

new usage
---
If we merge this PR and update the pip version, you should not have to make any changes to your code in a production environment what-so-ever. The same signature method of authentication will be used, any unit tests you have setup to introspect url parameters should see everything behaving as usual.

However, if you wish to switch production code to use the secret-based means of authentication, you should be able to do so like this:

BEFORE:
```
from mixpanel_query.client import MixpanelQueryClient

signature_client = MixpanelQueryClient(API_KEY, API_SECRET)
```

AFTER:
```
rom mixpanel_query.client import MixpanelQueryClient
from mixpanel_query.auth import SecretAuth

secret_client = MixpanelQueryClient(API_KEY, API_SECRET, auth_class=SecretAuth)
```

notes
---
* in the future, we can consider changing the default `auth_class` used by the client to be `SecretAuth`. We should most certainly do so if Mixpanel ever communicates their intent to discontinue support of the signature-based authentication method.
* thank you @drathm and @robin900 for your prior PRs on this (I leaned heavily on your PRs for the `SecretAuth` class.
* I have tested both authentication methods using the `get_segmentation` and `get_export` methods, and both are functioning well. I'd appreciate any additional tire-kicking folks can bring to the PR. 